### PR TITLE
Make channel query-version return simple version string

### DIFF
--- a/src/main/java/org/wildfly/prospero/extras/ReturnCodes.java
+++ b/src/main/java/org/wildfly/prospero/extras/ReturnCodes.java
@@ -20,4 +20,5 @@ package org.wildfly.prospero.extras;
 public class ReturnCodes {
     public static final Integer SUCCESS = 0;
     public static final Integer INVALID_ARGUMENTS = 1;
+    public static final Integer ERROR = 2;
 }

--- a/src/main/java/org/wildfly/prospero/extras/channel/query/QueryVersionCommand.java
+++ b/src/main/java/org/wildfly/prospero/extras/channel/query/QueryVersionCommand.java
@@ -1,8 +1,13 @@
 package org.wildfly.prospero.extras.channel.query;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.eclipse.aether.RepositorySystem;
 import org.wildfly.channel.ChannelMapper;
 import org.wildfly.channel.ChannelSession;
+import org.wildfly.channel.VersionResult;
 import org.wildfly.channel.maven.VersionResolverFactory;
 import org.wildfly.channel.spi.MavenVersionsResolver;
 import org.wildfly.prospero.extras.ReturnCodes;
@@ -16,6 +21,9 @@ import java.util.List;
 @CommandLine.Command(name = "query-version")
 public class QueryVersionCommand extends CommandWithHelp {
 
+    private static final JsonFactory JSON_FACTORY = new JsonFactory();
+    private static final ObjectMapper OBJECT_MAPPER = (new ObjectMapper(JSON_FACTORY)).configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+
     @CommandLine.Option(names={"--channel"}, required = false)
     private Path channelFile;
 
@@ -25,6 +33,9 @@ public class QueryVersionCommand extends CommandWithHelp {
     @CommandLine.Option(names={"--artifactId"})
     private String artifactId;
 
+    @CommandLine.Option(names={"--json"})
+    private boolean displayJson;
+
     @Override
     public Integer call() throws Exception {
         final MavenSessionManager msm = new MavenSessionManager();
@@ -32,7 +43,36 @@ public class QueryVersionCommand extends CommandWithHelp {
         MavenVersionsResolver.Factory factory = new VersionResolverFactory(system, msm.newRepositorySystemSession(system));
 
         ChannelSession ses = new ChannelSession(List.of(ChannelMapper.from(channelFile.toUri().toURL())), factory);
-        System.out.println(ses.findLatestMavenArtifactVersion(groupId, artifactId, null, null, null));
-        return ReturnCodes.SUCCESS;
+        final VersionResult version = ses.findLatestMavenArtifactVersion(groupId, artifactId, null, null, null);
+        if (version == null) {
+            System.err.printf("No version of artifact %s:%s found in the channel.%n", groupId, artifactId);
+            return ReturnCodes.ERROR;
+        } else {
+            if (displayJson) {
+                System.out.println(OBJECT_MAPPER.writeValueAsString(new JsonVersionResult(version)));
+            } else {
+                System.out.println(version.getVersion());
+            }
+            return ReturnCodes.SUCCESS;
+        }
+    }
+
+    class JsonVersionResult {
+
+        private final String version;
+        private final String channelName;
+
+        JsonVersionResult(VersionResult result) {
+            version = result.getVersion();
+            channelName = result.getChannelName().orElse(null);
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        public String getChannelName() {
+            return channelName;
+        }
     }
 }

--- a/src/main/resources/UsageMessages.properties
+++ b/src/main/resources/UsageMessages.properties
@@ -36,6 +36,12 @@ tools.channel.merge-repositories.manifest-url=the URL the new manifest can be re
 tools.channel.merge-repositories.description=optional text to use in description of the new channel.
 tools.channel.merge-repositories.name=optional name of the new channel.
 
+tools.channel.query-version.usage.header=Retrieves a version of artifact found in the channel.
+tools.channel.query-version.usage.description=Retrieves a version of artifact found in the channel. Returns error code (2) if no version is found
+tools.channel.query-version.groupId=Maven groupId coordinate of the artifact to find.
+tools.channel.query-version.artifactId=Maven artifactId coordinate of the artifact to find.
+tools.channel.query-version.json=Print the output in JSON format.
+
 usage.parameterListHeading = %nPositional parameters:%n
 usage.optionListHeading = %nOptions:%n
 usage.synopsisHeading = %nSyntax:%n


### PR DESCRIPTION
Bug fix - query-version used to return serialized org.wildfly.channel.VersionResult instead of version string
