### PR TITLE
Add LATEST_EXISTING manifest merge strategy

### DIFF
--- a/src/main/java/org/wildfly/prospero/extras/manifest/merge/VersionMergeStrategy.java
+++ b/src/main/java/org/wildfly/prospero/extras/manifest/merge/VersionMergeStrategy.java
@@ -5,7 +5,8 @@ import org.wildfly.channel.version.VersionMatcher;
 public interface VersionMergeStrategy {
     enum Strategies implements VersionMergeStrategy {
         LATEST(new LatestMergeStrategy()),
-        FIRST(new FirstMergeStrategy());
+        FIRST(new FirstMergeStrategy()),
+        LATEST_EXISTING(new LatestExistingMergeStrategy());
 
         private final VersionMergeStrategy mergeStrategy;
 
@@ -24,7 +25,7 @@ class FirstMergeStrategy implements VersionMergeStrategy {
 
     @Override
     public String merge(String v1, String v2) {
-        return v1;
+        return v1 == null ? v2 : v1;
     }
 }
 
@@ -32,10 +33,23 @@ class LatestMergeStrategy implements VersionMergeStrategy {
 
     @Override
     public String merge(String v1, String v2) {
+        if (v1 == null || v2 == null) {
+            return v1 == null ? v2 : v1;
+        }
         if (VersionMatcher.COMPARATOR.compare(v2, v1) > 0) {
             return v2;
         } else {
             return v1;
         }
+    }
+}
+
+class LatestExistingMergeStrategy extends LatestMergeStrategy {
+    @Override
+    public String merge(String v1, String v2) {
+        if (v1 == null) {
+            return null;
+        }
+        return super.merge(v1, v2);
     }
 }

--- a/src/test/java/org/wildfly/prospero/extras/manifest/merge/ManifestMergeCommandTest.java
+++ b/src/test/java/org/wildfly/prospero/extras/manifest/merge/ManifestMergeCommandTest.java
@@ -1,0 +1,48 @@
+package org.wildfly.prospero.extras.manifest.merge;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.wildfly.channel.ChannelManifest;
+import org.wildfly.channel.Stream;
+
+class ManifestMergeCommandTest {
+
+    protected static final ChannelManifest MANIFEST_ONE = new ChannelManifest(null, null, null, List.of(new Stream("org.test", "test-one", "1.0.0")));
+    protected static final ChannelManifest MANIFEST_TWO = new ChannelManifest(null, null, null, List.of(new Stream("org.test", "test-one", "1.1.0")));
+
+    @Test
+    public void pickFirstVersion() throws Exception {
+
+
+        final VersionMergeStrategy strategy = (v1, v2) -> v1;
+        final ChannelManifest merged = ManifestMergeCommand.merge(MANIFEST_ONE, MANIFEST_TWO, strategy, null, null);
+
+        assertThat(merged.getStreams())
+                .containsOnly(new Stream("org.test", "test-one", "1.0.0"));
+
+    }
+
+    @Test
+    public void pickSecondVersion() throws Exception {
+        final VersionMergeStrategy strategy = (v1, v2) -> v2;
+        final ChannelManifest merged = ManifestMergeCommand.merge(MANIFEST_ONE, MANIFEST_TWO, strategy, null, null);
+
+        assertThat(merged.getStreams())
+                .containsOnly(new Stream("org.test", "test-one", "1.1.0"));
+
+    }
+
+    @Test
+    public void rejectStream() throws Exception {
+        // if the strategy returns null, the stream should be removed
+        final VersionMergeStrategy strategy = (v1, v2) -> null;
+        final ChannelManifest merged = ManifestMergeCommand.merge(MANIFEST_ONE, MANIFEST_TWO, strategy, null, null);
+
+        assertThat(merged.getStreams())
+                .isEmpty();
+
+    }
+}

--- a/src/test/java/org/wildfly/prospero/extras/manifest/merge/VersionMergeStrategyTest.java
+++ b/src/test/java/org/wildfly/prospero/extras/manifest/merge/VersionMergeStrategyTest.java
@@ -11,6 +11,8 @@ class VersionMergeStrategyTest {
         final VersionMergeStrategy latest = new LatestMergeStrategy();
         assertEquals("1.2.4", latest.merge("1.2.3", "1.2.4"));
         assertEquals("1.2.4", latest.merge("1.2.4", "1.2.3"));
+        assertEquals("1.2.4", latest.merge("1.2.4", null));
+        assertEquals("1.2.4", latest.merge(null, "1.2.4"));
     }
 
     @Test
@@ -18,5 +20,16 @@ class VersionMergeStrategyTest {
         final VersionMergeStrategy first = new FirstMergeStrategy();
         assertEquals("1.2.3", first.merge("1.2.3", "1.2.4"));
         assertEquals("1.2.4", first.merge("1.2.4", "1.2.3"));
+        assertEquals("1.2.4", first.merge("1.2.4", null));
+        assertEquals("1.2.4", first.merge(null, "1.2.4"));
+    }
+
+    @Test
+    public void testLatestExistingVersionMerge() {
+        final VersionMergeStrategy strategy = new LatestExistingMergeStrategy();
+        assertEquals("1.2.4", strategy.merge("1.2.3", "1.2.4"));
+        assertEquals("1.2.4", strategy.merge("1.2.4", "1.2.3"));
+        assertEquals("1.2.4", strategy.merge("1.2.4", null));
+        assertNull(strategy.merge(null, "1.2.4"));
     }
 }


### PR DESCRIPTION
When using LATEST_EXISTING merge strategy, the versions will be merged in the same way as LATEST strategy, but streams not present in the first manifest will be dropped..
