### PR TITLE
Select schemaVersion based on input manifests

### DIFF
--- a/src/main/java/org/wildfly/prospero/extras/manifest/ManifestUtils.java
+++ b/src/main/java/org/wildfly/prospero/extras/manifest/ManifestUtils.java
@@ -1,0 +1,26 @@
+package org.wildfly.prospero.extras.manifest;
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.wildfly.channel.ChannelManifest;
+import org.wildfly.channel.version.VersionMatcher;
+
+public class ManifestUtils {
+
+    /**
+     * Returns the latest version of the manifest used in the input manfiests
+     *
+     * @param manifestOne
+     * @param manifestTwo
+     * @return
+     */
+    public static Optional<String> getLatestSchemaVersion(ChannelManifest manifestOne, ChannelManifest manifestTwo) {
+        final Optional<String> schemaVersion;
+        if (manifestOne.getSchemaVersion().equals(manifestTwo.getSchemaVersion()))
+            schemaVersion = Optional.of(manifestOne.getSchemaVersion());
+        else
+            schemaVersion = VersionMatcher.getLatestVersion(Set.of(manifestOne.getSchemaVersion(), manifestTwo.getSchemaVersion()));
+        return schemaVersion;
+    }
+}

--- a/src/main/java/org/wildfly/prospero/extras/manifest/merge/ManifestMergeCommand.java
+++ b/src/main/java/org/wildfly/prospero/extras/manifest/merge/ManifestMergeCommand.java
@@ -4,12 +4,14 @@ import org.wildfly.channel.ChannelManifest;
 import org.wildfly.channel.ChannelManifestMapper;
 import org.wildfly.channel.Stream;
 import org.wildfly.prospero.extras.ReturnCodes;
+import org.wildfly.prospero.extras.manifest.ManifestUtils;
 import picocli.CommandLine;
 
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.Callable;
@@ -84,6 +86,13 @@ public class ManifestMergeCommand implements Callable<Integer> {
             }
         }
 
-        return new ChannelManifest(mergedManifestName, mergedManifestId, null, merged);
+        final Optional<String> schemaVersion = ManifestUtils.getLatestSchemaVersion(manifestOne, manifestTwo);
+        final ChannelManifest.Builder builder = new ChannelManifest.Builder()
+                .setSchemaVersion(schemaVersion.orElse(ChannelManifestMapper.CURRENT_SCHEMA_VERSION))
+                .setName(mergedManifestName)
+                .addStreams(merged.toArray(new Stream[]{}))
+                .setId(mergedManifestId);
+
+        return builder.build();
     }
 }


### PR DESCRIPTION
When generating a new manifest in merge operation, use the latest
version of manifest used
